### PR TITLE
Fix rotate3d in Firefox

### DIFF
--- a/src/traqball.js
+++ b/src/traqball.js
@@ -21,10 +21,11 @@
         spin	= 1;
     }else if(/explorer/gi.test(userAgent)){
         prefix = "-ms-";
-        cssPref = "MS";
+        cssPref = "ms";
     }else if(/mozilla/gi.test(userAgent)){
         prefix = "-moz-";
         cssPref = "Moz";
+        spin = 1;
     }else if(/opera/gi.test(userAgent)){
         prefix = "-o-";
         cssPref = "O";


### PR DESCRIPTION
The "reverse direction bug with rotate3d" is also present in Firefox... Maybe it's not a bug.
Microsoft prefix in the DOM API is "ms", not "MS".
