### PR TITLE
clickable/touchable area distinct from displayed element

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ var mytraqball = new Traqball(configurationObject);
 
 ``` js
 {	
-	stage:				"stage", 			// id of block element. String, default value: <body>
+	stage:				"stage", 			// id (String) of block element or selected DOM-Element. Default value: <body>
 	axis: 				[0.5,1,0.25], 		// X,Y,Z values of initial rotation vector. Array, default value: [1,0,0]
 	angle: 				0.12,				// Initial rotation angle in radian. Float, default value: 0.
 	perspective: 		perspectiveValue,	// Perspective. Integer, default value 700.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ var mytraqball = new Traqball(configurationObject);
 ``` js
 {	
 	stage:				"stage", 			// id (String) of block element or selected DOM-Element. Default value: <body>
+	activationElement:	"stage", 			// DOM-Element that catches the events. Default value: first child of stage (the rotating element)
 	axis: 				[0.5,1,0.25], 		// X,Y,Z values of initial rotation vector. Array, default value: [1,0,0]
 	angle: 				0.12,				// Initial rotation angle in radian. Float, default value: 0.
 	perspective: 		perspectiveValue,	// Perspective. Integer, default value 700.

--- a/demo/js/traqball.js
+++ b/demo/js/traqball.js
@@ -88,7 +88,9 @@
          })();
         
     var Traqball = function(confObj){
-        this.config = {};
+        this.config = {
+            stage: document.body
+        };
         this.box = null;
         
         this.setup(confObj);
@@ -127,8 +129,11 @@
             for(var prop in conf){
                 THIS.config[prop] = conf[prop];
                 }
-                
-            stage	= document.getElementById(THIS.config.stage) || document.getElementsByTagname("body")[0];
+
+            if (typeof THIS.config.stage === 'string') {
+                THIS.config.stage = document.getElementById(THIS.config.stage);
+            }
+            stage	= THIS.config.stage;
             pos 	= findPos(stage);
             angle 	= THIS.config.angle || 0;
             impulse	= THIS.config.impulse === false ? false : true;

--- a/demo/js/traqball.js
+++ b/demo/js/traqball.js
@@ -98,7 +98,7 @@
     
     Traqball.prototype.disable = function(){
         if(this.box !== null){
-            bindEvent(this.box, 'touchstart', this.evHandlers[0], "remove");
+            bindEvent(this.config.activationArea, 'touchstart', this.evHandlers[0], "remove");
             bindEvent(document, 'touchmove', this.evHandlers[1], "remove");
             bindEvent(document, 'touchend', this.evHandlers[2], "remove");
         }
@@ -106,7 +106,7 @@
     
     Traqball.prototype.activate = function(){
         if(this.box !== null){
-            bindEvent(this.box, 'touchstart', this.evHandlers[0]);
+            bindEvent(this.config.activationArea, 'touchstart', this.evHandlers[0]);
             bindEvent(document, 'touchmove', this.evHandlers[1], "remove");
             bindEvent(document, 'touchend', this.evHandlers[2], "remove");
         }
@@ -154,6 +154,9 @@
                     THIS.box = child;
                     break;
                 }
+            }
+            if (typeof THIS.config.activationArea === 'undefined') {
+                THIS.config.activationArea = THIS.box;
             }
             
             var perspective	= getStyle(stage, prefix+"perspective"),
@@ -224,7 +227,7 @@
 
             THIS.box.dispatchEvent(startEvent);
 
-            bindEvent(THIS.box,'touchstart', startrotation, "remove");
+            bindEvent(THIS.config.activationArea,'touchstart', startrotation, "remove");
             bindEvent(document, 'touchmove', rotate);
             bindEvent(document, 'touchend', finishrotation);			
         }
@@ -234,7 +237,7 @@
         
             bindEvent(document, 'touchmove', rotate, "remove");
             bindEvent(document, 'touchend', finishrotation, "remove");
-            bindEvent(THIS.box, 'touchstart', startrotation);
+            bindEvent(THIS.config.activationArea, 'touchstart', startrotation);
             calcSpeed();
 
             THIS.box.dispatchEvent(releaseEvent);

--- a/src/traqball.js
+++ b/src/traqball.js
@@ -88,7 +88,9 @@
          })();
         
     var Traqball = function(confObj){
-        this.config = {};
+        this.config = {
+            stage: document.body
+        };
         this.box = null;
         
         this.setup(confObj);
@@ -127,8 +129,11 @@
             for(var prop in conf){
                 THIS.config[prop] = conf[prop];
                 }
-                
-            stage	= document.getElementById(THIS.config.stage) || document.getElementsByTagname("body")[0];
+
+            if (typeof THIS.config.stage === 'string') {
+                THIS.config.stage = document.getElementById(THIS.config.stage);
+            }
+            stage	= THIS.config.stage;
             pos 	= findPos(stage);
             angle 	= THIS.config.angle || 0;
             impulse	= THIS.config.impulse === false ? false : true;

--- a/src/traqball.js
+++ b/src/traqball.js
@@ -211,7 +211,7 @@
             }
             
             THIS.box.style[cssPref+"Transform"] = "matrix3d("+ startMatrix+")";
-            bindEvent(THIS.box, 'touchstart', startrotation);
+            bindEvent(THIS.config.activationArea, 'touchstart', startrotation);
             
             THIS.evHandlers = [startrotation, rotate, finishrotation];
         })();

--- a/src/traqball.js
+++ b/src/traqball.js
@@ -98,7 +98,7 @@
     
     Traqball.prototype.disable = function(){
         if(this.box !== null){
-            bindEvent(this.box, 'touchstart', this.evHandlers[0], "remove");
+            bindEvent(this.config.activationArea, 'touchstart', this.evHandlers[0], "remove");
             bindEvent(document, 'touchmove', this.evHandlers[1], "remove");
             bindEvent(document, 'touchend', this.evHandlers[2], "remove");
         }
@@ -106,7 +106,7 @@
     
     Traqball.prototype.activate = function(){
         if(this.box !== null){
-            bindEvent(this.box, 'touchstart', this.evHandlers[0]);
+            bindEvent(this.config.activationArea, 'touchstart', this.evHandlers[0]);
             bindEvent(document, 'touchmove', this.evHandlers[1], "remove");
             bindEvent(document, 'touchend', this.evHandlers[2], "remove");
         }
@@ -154,6 +154,9 @@
                     THIS.box = child;
                     break;
                 }
+            }
+            if (typeof THIS.config.activationArea === 'undefined') {
+                THIS.config.activationArea = THIS.box;
             }
             
             var perspective	= getStyle(stage, prefix+"perspective"),
@@ -224,7 +227,7 @@
 
             THIS.box.dispatchEvent(startEvent);
 
-            bindEvent(THIS.box,'touchstart', startrotation, "remove");
+            bindEvent(THIS.config.activationArea,'touchstart', startrotation, "remove");
             bindEvent(document, 'touchmove', rotate);
             bindEvent(document, 'touchend', finishrotation);			
         }
@@ -234,7 +237,7 @@
         
             bindEvent(document, 'touchmove', rotate, "remove");
             bindEvent(document, 'touchend', finishrotation, "remove");
-            bindEvent(THIS.box, 'touchstart', startrotation);
+            bindEvent(THIS.config.activationArea, 'touchstart', startrotation);
             calcSpeed();
 
             THIS.box.dispatchEvent(releaseEvent);


### PR DESCRIPTION
this patch enables specifying your own "mouse-down-element". We had a bug where we could hardly rotate the ball, when it was orthogonal to the display pane. Specifying another element (which is not rotated) fixes this. In our project, we actually use the same element as config.stage, but we felt it would be better to keep it flexible. The change is contained in commit c550317f, the other ones are just "the path there".
